### PR TITLE
Fixed React 19 getOwner runtime error by externalizing react/jsx-runtime

### DIFF
--- a/react/react-components/package.json
+++ b/react/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-react-components",
-  "version": "2.0.0-dev-14",
+  "version": "2.0.0-dev-15",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/main.js",
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "@cyntler/react-doc-viewer": "1.10.3",
-    "@egovernments/digit-ui-components": "2.0.0-dev-48",
+    "@egovernments/digit-ui-components": "2.0.0-dev-52",
     "@egovernments/digit-ui-svg-components": "2.0.0-dev-01",
     "@googlemaps/js-api-loader": "1.13.10",
     "@hookform/resolvers": "1.3.7",

--- a/react/storybook/package.json
+++ b/react/storybook/package.json
@@ -47,7 +47,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@egovernments/digit-ui-components": "2.0.0-dev-48",
+    "@egovernments/digit-ui-components": "2.0.0-dev-52",
     "@egovernments/digit-ui-components-css": "2.0.0-dev-12",
     "@egovernments/digit-ui-libraries": "2.0.0-dev-11",
     "@egovernments/digit-ui-svg-components": "2.0.0-dev-01",

--- a/react/ui-components/package.json
+++ b/react/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-components",
-  "version": "2.0.0-dev-51",
+  "version": "2.0.0-dev-52",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/main.js",

--- a/react/ui-components/webpack.config.js
+++ b/react/ui-components/webpack.config.js
@@ -36,6 +36,13 @@ module.exports = (env, argv) => {
         amd: 'react-dom',
         root: 'ReactDOM',
       },
+      'react/jsx-runtime': { 
+        commonjs: 'react/jsx-runtime', 
+        commonjs2: 'react/jsx-runtime' 
+      },
+      'react/jsx-dev-runtime': { 
+        commonjs: 'react/jsx-dev-runtime', 
+        commonjs2: 'react/jsx-dev-runtime' },
       // Router and state management
       'react-router-dom': 'react-router-dom',
       'react-i18next': 'react-i18next',


### PR DESCRIPTION
Added react/jsx-runtime and react/jsx-dev-runtime to webpack externals in core, workbench, and digit-ui-components packages to prevent each package from bundling its own copy of the JSX runtime, which causes duplicate ReactSharedInternals references and the "e.getOwner is not a function" error at runtime.