### PR TITLE
BUGFIX/HCMPRE-3969::Fixed React 19 getOwner runtime error by externalizing react/jsx-runtime

### DIFF
--- a/react/libraries/package.json
+++ b/react/libraries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-libraries",
-  "version": "2.0.0-dev-13",
+  "version": "2.0.0-dev-12",
   "main": "dist/main.js",
   "module": "dist/main.js",
   "source": "src/index.js",

--- a/react/libraries/package.json
+++ b/react/libraries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-libraries",
-  "version": "2.0.0-dev-11",
+  "version": "2.0.0-dev-13",
   "main": "dist/main.js",
   "module": "dist/main.js",
   "source": "src/index.js",

--- a/react/libraries/webpack.config.js
+++ b/react/libraries/webpack.config.js
@@ -36,6 +36,14 @@ module.exports = (env, argv) => {
         amd: 'react-dom',
         root: 'ReactDOM',
       },
+      "react/jsx-runtime": {
+        commonjs: "react/jsx-runtime",
+        commonjs2: "react/jsx-runtime",
+      },
+      "react/jsx-dev-runtime": {
+        commonjs: "react/jsx-dev-runtime",
+        commonjs2: "react/jsx-dev-runtime",
+      },
       // Router and state management
       'react-router-dom': 'react-router-dom',
       'react-i18next': 'react-i18next',

--- a/react/react-components/package.json
+++ b/react/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-react-components",
-  "version": "2.0.0-dev-15",
+  "version": "2.0.0-dev-16",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/main.js",
@@ -62,7 +62,7 @@
   "dependencies": {
     "@cyntler/react-doc-viewer": "1.10.3",
     "@egovernments/digit-ui-components": "2.0.0-dev-52",
-    "@egovernments/digit-ui-svg-components": "2.0.0-dev-01",
+    "@egovernments/digit-ui-svg-components": "2.0.0-dev-05",
     "@googlemaps/js-api-loader": "1.13.10",
     "@hookform/resolvers": "1.3.7",
     "ajv": "8.11.2",
@@ -75,7 +75,7 @@
     "react-i18next": "15.0.0",
     "react-joyride": "2.5.5",
     "react-table": "7.7.0",
-    "@egovernments/digit-ui-libraries": "2.0.0-dev-11"
+    "@egovernments/digit-ui-libraries": "2.0.0-dev-13"
   },
   "resolutions": {
     "**/ajv": "8.11.2",

--- a/react/react-components/package.json
+++ b/react/react-components/package.json
@@ -75,7 +75,7 @@
     "react-i18next": "15.0.0",
     "react-joyride": "2.5.5",
     "react-table": "7.7.0",
-    "@egovernments/digit-ui-libraries": "2.0.0-dev-13"
+    "@egovernments/digit-ui-libraries": "2.0.0-dev-12"
   },
   "resolutions": {
     "**/ajv": "8.11.2",

--- a/react/react-components/package.json
+++ b/react/react-components/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "@cyntler/react-doc-viewer": "1.10.3",
-    "@egovernments/digit-ui-components": "2.0.0-dev-52",
+    "@egovernments/digit-ui-components": "2.0.0-dev-53",
     "@egovernments/digit-ui-svg-components": "2.0.0-dev-05",
     "@googlemaps/js-api-loader": "1.13.10",
     "@hookform/resolvers": "1.3.7",

--- a/react/react-components/webpack.config.js
+++ b/react/react-components/webpack.config.js
@@ -36,6 +36,14 @@ module.exports = (env, argv) => {
         amd: 'react-dom',
         root: 'ReactDOM',
       },
+      "react/jsx-runtime": {
+        commonjs: "react/jsx-runtime",
+        commonjs2: "react/jsx-runtime",
+      },
+      "react/jsx-dev-runtime": {
+        commonjs: "react/jsx-dev-runtime",
+        commonjs2: "react/jsx-dev-runtime",
+      },
       // Router and state management
       'react-router-dom': 'react-router-dom',
       'react-i18next': 'react-i18next',

--- a/react/storybook/package.json
+++ b/react/storybook/package.json
@@ -49,8 +49,8 @@
   "dependencies": {
     "@egovernments/digit-ui-components": "2.0.0-dev-52",
     "@egovernments/digit-ui-components-css": "2.0.0-dev-12",
-    "@egovernments/digit-ui-libraries": "2.0.0-dev-11",
-    "@egovernments/digit-ui-svg-components": "2.0.0-dev-01",
+    "@egovernments/digit-ui-libraries": "2.0.0-dev-13",
+    "@egovernments/digit-ui-svg-components": "2.0.0-dev-05",
     "react-data-table-component": "7.6.2",
     "react-datepicker": "^8.7.0",
     "react-drag-drop-files": "2.3.10",

--- a/react/storybook/package.json
+++ b/react/storybook/package.json
@@ -47,7 +47,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@egovernments/digit-ui-components": "2.0.0-dev-52",
+    "@egovernments/digit-ui-components": "2.0.0-dev-53",
     "@egovernments/digit-ui-components-css": "2.0.0-dev-12",
     "@egovernments/digit-ui-libraries": "2.0.0-dev-12",
     "@egovernments/digit-ui-svg-components": "2.0.0-dev-05",

--- a/react/storybook/package.json
+++ b/react/storybook/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@egovernments/digit-ui-components": "2.0.0-dev-52",
     "@egovernments/digit-ui-components-css": "2.0.0-dev-12",
-    "@egovernments/digit-ui-libraries": "2.0.0-dev-13",
+    "@egovernments/digit-ui-libraries": "2.0.0-dev-12",
     "@egovernments/digit-ui-svg-components": "2.0.0-dev-05",
     "react-data-table-component": "7.6.2",
     "react-datepicker": "^8.7.0",

--- a/react/svg-components/package.json
+++ b/react/svg-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-svg-components",
-  "version": "2.0.0-dev-04",
+  "version": "2.0.0-dev-05",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/main.js",

--- a/react/svg-components/webpack.config.js
+++ b/react/svg-components/webpack.config.js
@@ -35,7 +35,15 @@ module.exports = (env, argv) => {
         commonjs2: 'react-dom',
         amd: 'react-dom',
         root: 'ReactDOM',
-      }
+      },
+      "react/jsx-runtime": {
+        commonjs: "react/jsx-runtime",
+        commonjs2: "react/jsx-runtime",
+      },
+      "react/jsx-dev-runtime": {
+        commonjs: "react/jsx-dev-runtime",
+        commonjs2: "react/jsx-dev-runtime",
+      },
       // SVG components typically don't need router/state management externals
     },
     module: {

--- a/react/ui-components/package.json
+++ b/react/ui-components/package.json
@@ -67,8 +67,8 @@
     "dist"
   ],
   "dependencies": {
-    "@egovernments/digit-ui-svg-components": "2.0.0-dev-01",
-    "@egovernments/digit-ui-libraries": "2.0.0-dev-11",
+    "@egovernments/digit-ui-svg-components": "2.0.0-dev-05",
+    "@egovernments/digit-ui-libraries": "2.0.0-dev-13",
     "@egovernments/digit-ui-components-css":"2.0.0-dev-12",
     "@googlemaps/js-api-loader": "1.13.10",
     "@cyntler/react-doc-viewer": "1.10.3",

--- a/react/ui-components/package.json
+++ b/react/ui-components/package.json
@@ -68,7 +68,7 @@
   ],
   "dependencies": {
     "@egovernments/digit-ui-svg-components": "2.0.0-dev-05",
-    "@egovernments/digit-ui-libraries": "2.0.0-dev-13",
+    "@egovernments/digit-ui-libraries": "2.0.0-dev-12",
     "@egovernments/digit-ui-components-css":"2.0.0-dev-12",
     "@googlemaps/js-api-loader": "1.13.10",
     "@cyntler/react-doc-viewer": "1.10.3",

--- a/react/ui-components/package.json
+++ b/react/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egovernments/digit-ui-components",
-  "version": "2.0.0-dev-52",
+  "version": "2.0.0-dev-53",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/main.js",


### PR DESCRIPTION
Added fix for externalizing react/jsx-runtime in other modules: libraries, svg-components, react-components