### PR TITLE
Bump version to 0.3.1 and update changelog

### DIFF
--- a/flutter/digit-ui-components/digit_components/CHANGELOG.md
+++ b/flutter/digit-ui-components/digit_components/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 0.3.0+4
+## 0.3.1
+* Toast message now wraps up to three lines instead of truncating.
+* PanelCard content is clipped to its rounded shape.
+* Success/error panel adopts the 12px card border radius.
+* SelectionCard fills its container with a 16px inset and reverts option padding to 8dp vertical.
+* Fixed SelectionCard crash when placed under intrinsic-dimension ancestors.
+* InfoCard, Popup, and sync dialog component alignment and styling fixes.
 * Clip lottie animation in popup for fixed dimension.
 * Tags can now take border color property.
 * New camera icon, add_circle icon and spacer constants.
-* Sidebar Digit button is now of type primary. 
+* Sidebar Digit button is now of type primary.
 * Fixed dropdown body shadow visibility issue for dropdown fields.
 * Added border radius for panel cards.
 * Fixed alignment of toast messages and validation text belonging to radio buttons.

--- a/flutter/digit-ui-components/digit_components/pubspec.yaml
+++ b/flutter/digit-ui-components/digit_components/pubspec.yaml
@@ -1,6 +1,6 @@
 name: digit_ui_components
 description: A collection of reusable Flutter UI components, including atoms, molecules, and wrapper widgets, designed for consistent, scalable, and efficient UI development.
-version:  0.3.0+2
+version:  0.3.1
 homepage: https://github.com/egovernments/DIGIT-UI-LIBRARIES/tree/master/flutter/digit-ui-components
 repository: https://github.com/egovernments/DIGIT-UI-LIBRARIES
 issue_tracker: https://github.com/egovernments/DIGIT-UI-LIBRARIES/issues


### PR DESCRIPTION
Consolidates unpublished 0.3.0+4 changelog entry with new HCM v2.1 UX audit fixes into a single 0.3.1 release. pub.dev latest is 0.3.0+3, so 0.3.0+4 was never actually published; folding both into 0.3.1 avoids a version gap on pub.dev.